### PR TITLE
Update manual link to point to the manual on the website

### DIFF
--- a/extensions/faq.py
+++ b/extensions/faq.py
@@ -10,14 +10,14 @@ class Faq(commands.Cog):
 		await ctx.send(
 'The Practice ROM can be downloaded here: \
 <https://practicerom.com/>')
-	
+
 	@commands.command()
 	async def manual(self, ctx):
 		await ctx.send(
 'Make sure to read the gz manual so you understand \
 the tools you have available to you: \
-<https://github.com/glankk/gz/blob/master/USAGE.md>')
-	
+<https://practicerom.com/manual>')
+
 	@commands.command()
 	async def gzemu(self, ctx):
 		await ctx.send(
@@ -60,7 +60,7 @@ For any Item Randomizer related questions please join this server here: https://
 	async def glitchless(self, ctx):
 		await ctx.send(
 'This server has more channels dedicated to learning glitchless categories: https://discordapp.com/invite/MeeMcZU')
-	
+
 	@commands.command()
 	async def beginner(self, ctx):
 		await ctx.send(

--- a/extensions/faq.py
+++ b/extensions/faq.py
@@ -16,7 +16,7 @@ class Faq(commands.Cog):
 		await ctx.send(
 'Make sure to read the gz manual so you understand \
 the tools you have available to you: \
-<https://practicerom.com/manual>')
+<https://practicerom.com/manual/>')
 
 	@commands.command()
 	async def gzemu(self, ctx):


### PR DESCRIPTION
Just changed the URL to point to the website instead: https://practicerom.com/manual/

Going to get both you and Glank's public keys to be able to update the site yourself.