### PR TITLE
Watches - Add download links to import files from the website

### DIFF
--- a/extensions/faq.py
+++ b/extensions/faq.py
@@ -37,7 +37,10 @@ Import Files - Place on your SD Card for importing:\n\
 1.0 Watches Download: https://practicerom.com/watches?version=1.0\n\
 1.1 Watches Download: https://practicerom.com/watches?version=1.1\n\
 1.2 / VC Watches Download: https://practicerom.com/watches?version=1.2\n\
-Master Quest Watches Download: https://practicerom.com/watches?version=mq')
+Gamecube NTSC-J Watches Download: https://practicerom.com/watches?version=gcj\n\
+Gamecube NTSC-U Watches Download: https://practicerom.com/watches?version=gc\n\
+Master Quest NTSC-J Watches Download: https://practicerom.com/watches?version=mqj\n\
+Master Quest NTSC-U Watches Download: https://practicerom.com/watches?version=mq')
 
 	@commands.command()
 	async def ultimate(self, ctx):

--- a/extensions/faq.py
+++ b/extensions/faq.py
@@ -31,7 +31,13 @@ Guide: <https://imgur.com/a/bCdVV>')
 	async def watches(self, ctx):
 		await ctx.send(
 'To see values from RAM in the Practice ROM, you need to use the Watches menu.\n\
-Address and flags list: <https://bthl.es/0f>')
+Address and flags list: <https://bthl.es/0f>\n\
+\n\
+Import Files - Place on your SD Card for importing:\n\
+1.0 Watches Download: https://practicerom.com/watches?version=1.0\n\
+1.1 Watches Download: https://practicerom.com/watches?version=1.1\n\
+1.2 / VC Watches Download: https://practicerom.com/watches?version=1.2\n\
+Master Quest Watches Download: https://practicerom.com/watches?version=mq')
 
 	@commands.command()
 	async def ultimate(self, ctx):


### PR DESCRIPTION
Script on the site parses the spreadsheet and supplies an import file depending on the version specified in the flag.

E.g:
https://practicerom.com/watches?version=x

Replace x with:
leave blank / invalid version = Version 1.0
```
N64 Roms:
==========
1.0 = Version 1.0
1.1 = Version 1.1
1.2 = Version 1.2 / VC

Wii VC
==========
vc = Version 1.2 / VC
wii = Version 1.2 / VC
wiivc = Version 1.2 / VC
virtualconsole = Version 1.2 / VC

Master Quest
==========
mqj = Master Quest NTSC-J
mq-j = Master Quest NTSC-J
masterquestj = Master Quest NTSC-J
masterquest-j = Master Quest NTSC-J
mq = Master Quest NTSC-U
masterquest = Master Quest NTSC-U

Gamecube:
==========
gcj = Gamecube NTSC-J
gc-j = Gamecube NTSC-J
gamecubej = Gamecube NTSC-J
gamecube-j = Gamecube NTSC-J
gamecube = Gamecube NTSC-U
gc = Gamecube NTSC-U
```
* Ignores any watches without a type, or, correct value supplied in the requested value's column. 