### PR TITLE
Attach embed of removed message

### DIFF
--- a/ootBot.py
+++ b/ootBot.py
@@ -34,8 +34,10 @@ async def on_message(message):
 	if channel_id == strats_id:
 		if not url:
 			if not media:
+				embed=discord.Embed(color=sender.color, description=message.content)
+				embed.set_author(name=sender.display_name, icon_url=sender.avatar_url)
+				await discussion.send(sender.mention + ' ' + strats.mention + ' is for videos only. Discussion should happen here instead.', embed=embed)
 				await message.delete()
-				await discussion.send(sender.mention + ' ' + strats.mention + ' is for videos only. Discussion should happen here instead.')
 
 #ready
 @client.event


### PR DESCRIPTION
## Description 
This pull requests copies removed messages from the `strats_id` channel to the `discussion_id` channel using an embed so users no longer have to re-type their message out when it gets nuked. 

## Image 
![image](https://user-images.githubusercontent.com/22358804/148757943-be8dc523-7cd7-4ef3-83b9-47bdcbbb37e2.png)
