### PR TITLE
Auto-update, Loop Scripts, and Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.txt
 /extensions/__pycache__/
+./config.txt
+/__pycache__/

--- a/ootBot.py
+++ b/ootBot.py
@@ -1,8 +1,14 @@
+#! /bin/env python3
+
 import re
 import discord
 from discord.ext import commands
+from updater import BotConfig
+import sys
 
-discord_token = ''
+config = BotConfig()
+
+discord_token = config.get('Bot Settings', 'discord_token')
 
 #create bot
 client = commands.Bot(command_prefix = '!')
@@ -25,8 +31,8 @@ async def on_message(message):
 	channel_id    = message.channel.id
 	media         = message.attachments
 	sender        = message.author
-	strats_id     = 357309453311148032
-	discussion_id = 495387041161543690
+	strats_id     = int(config.get('Server Settings', 'strats_id'))
+	discussion_id = int(config.get('Server Settings', 'discussion_id'))
 	strats        = client.get_channel(strats_id)
 	discussion    = client.get_channel(discussion_id)
 	url           = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]\
@@ -45,6 +51,9 @@ async def on_message(message):
 async def on_ready():
 	print('ootBot is online')
 	print('----------------')
+
+#update
+config.create_update_timer(client)
 
 #run
 client.run(discord_token)

--- a/run-loop.bat
+++ b/run-loop.bat
@@ -1,0 +1,5 @@
+rem Looping script for running the auto-updating OoT Bot on Windows
+
+:loop
+python.exe ootBot.py
+goto loop

--- a/run-loop.sh
+++ b/run-loop.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+while :
+do
+	python ./ootBot.py
+done

--- a/updater.py
+++ b/updater.py
@@ -1,0 +1,79 @@
+import configparser
+import sys
+import os.path
+
+import subprocess
+
+import asyncio
+
+class BotConfig:
+	def __init__(self):
+		self.config = configparser.ConfigParser()
+		self.config.read('config.txt')
+		if not self.config.sections():
+			# no config available
+			self.create_default()
+		self.print()
+
+	def get(self, section, key):
+		return self.config[section][key]
+
+	def create_default(self):
+		# make a new config
+		self.config = configparser.ConfigParser()
+		self.config['Server Settings'] = {
+			'strats_id': 357309453311148032,
+			'discussion_id': 495387041161543690
+		}
+		self.config['Bot Settings'] = {
+			'discord_token': 'REPLACE_WITH_YOUR_DISCORD_TOKEN'
+		}
+		self.config['GitHub'] = {
+			'is_repo': 'n'
+		}
+		with open('config.txt', 'w') as f: self.config.write(f)
+		self.set()
+
+	def set(self):
+		for section in self.config:
+			if section == "DEFAULT": continue
+			print(f'[{section}]')
+			for key in self.config[section]:
+				value = input(f'{key}? ({self.config[section][key]}):')
+				if value: 
+					self.config[section][key] = value
+		with open('config.txt', 'w') as f: self.config.write(f)
+
+	def print(self):
+		print("----------------")
+		print("|    config    |")
+		print("----------------")
+		# print out each non default section of config
+		for section in self.config:
+			if section == "DEFAULT": continue
+			print(f'[{section}]')
+			for key in self.config[section]:
+				value = self.config[section][key]
+				# don't print the discord token lol
+				if key == 'discord_token':
+					value = f'{value[:12]}...'
+				print(f'{key} = {value}')
+			print('')
+
+	def create_update_timer(self, bot):
+		if (self.get('GitHub', 'is_repo') == 'y'):
+			bot.loop.create_task(self.timer())
+
+	async def timer(self):
+		while True:
+			await asyncio.sleep(60)
+			subprocess.check_output(["git", "fetch"])
+			output = subprocess.check_output(["git", "status"])
+			output = output.decode("utf-8")
+			if 'Your branch is behind' not in output:
+				continue
+			print("Update detected, pulling and exiting...")
+			output = subprocess.check_output(["git", "pull"])
+			output = output.decode("utf-8")
+			print(output)
+			sys.exit(0) 


### PR DESCRIPTION
# Auto-update, Loop Scripts, and Config
## Description
This commit does a few things: automatically update the bot when in a git repository (currently set to check every minute), and makes the bot use a configuration file so manual editing of the python doesn't need to be done every time an update is pulled or the bot is deployed otherwise. 

## Configuration File
If you do not have a configuration file already made, the bot will ask for your input before starting up. The bot assumes default values if you do not provide them (shown in parenthesis), however you are expected to provide your bot's discord token for it to work properly. 

When declaring the bot's code is in a repo, it will activate the auto-updater.
```
C:\Users\Savestate\github\ootBot>python.exe ootBot.py
[Server Settings]
strats_id? (357309453311148032):
discussion_id? (495387041161543690):
[Bot Settings]
discord_token? (REPLACE_WITH_YOUR_DISCORD_TOKEN):OTMwMDUwN...
[GitHub]
is_repo? (n):y
```

## Auto-updater
The auto updater works by calling `git fetch` every minute, and checking `git status` to see if the repository is behind. If so, it will `git pull` and call `sys.exit(0)`. 

Normally this would just close python and stop the bot, however two looping scripts have been provided depending on what platform you're using. `run-loop.bat` for Windows systems and `run-loop.sh` for Linux.

It's pretty rudimentary but it gets the job done for a single use bot without having to set up any extra infrastructure. 