### PR TITLE
Add self-destruct command

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -31,6 +31,12 @@ class BotConfig:
 		self.config['GitHub'] = {
 			'is_repo': 'n'
 		}
+		self.config['Extra'] = {
+			'enabled': 'n',
+			'command': 'command_name',
+			'message': 'message to the\ninvoker here!',
+			'error': 'when dms are closed...'
+		}
 		with open('config.txt', 'w') as f: self.config.write(f)
 		self.set()
 


### PR DESCRIPTION
# Add self-destruct command
## Description
This feature allows for adding a single self-destructing custom command managed by the bot's configuration. 

**Basic Functionality**: The command will DM the invoker a message determined by the configuration and then delete it after 30 seconds. 

**Error Handling**: If the user has DMs closed, it will let them know in the channel the command was invoked in and then delete both the command message and response after 10 seconds. 

## Example
Example configuration in `config.txt`:
```
[Extra]
enabled = y
command = heythere
message = Hi there! 
	This message will delete itself in 30 seconds.
	Goodbye now!
error = Your DMs are closed. Please temporarily enable them and try again.
```