### PR TITLE
Generate link to bookmark for video discussion

### DIFF
--- a/ootBot.py
+++ b/ootBot.py
@@ -41,6 +41,10 @@ async def on_message(message):
 	url           = re.findall(url_re, message.content)
 
 	# handling text posted in the strats channel
+	if sender.id == client.user.id:
+		# bail if post is from the bot itself
+		return
+
 	if channel_id == strats_id:
 		if not url:
 			if not media:
@@ -56,7 +60,11 @@ async def on_message(message):
 		strat_url = media[0].url if media else url[0][0]
 		embed.add_field(name="Link to video", value=strat_url, inline=False)
 		embed.set_footer(text="New video posted!")
-		await discussion.send(embed=embed)
+		bookmark = await discussion.send(embed=embed)
+
+		# now make a link to the bookmark in the strats channel
+		embed=discord.Embed(color=sender.color, title="View discussion for this video →", url=bookmark.jump_url)
+		await strats.send(embed=embed)
 
 	# handling when the extra command is invoked
 	if config.get('Extra', 'enabled') == 'y':


### PR DESCRIPTION
# Quickly jump to a video discussion bookmark
## Description
This commit makes ootBot generate a clickable shortcut to the discussion bookmark for when a video is posted, allowing for easily accessing relevant discussion without having to search again for the bookmark itself.

## Usage
Posting a video in the videos channel will generate a clickable link to take you to the discussion bookmark

Clicking this:
![image](https://user-images.githubusercontent.com/22358804/175782452-c40ad8ab-4ba8-491c-983d-443be71535a6.png)

Will jump you to this bookmark:
![image](https://user-images.githubusercontent.com/22358804/175782464-787e99eb-05f0-4aad-9022-250f83029d96.png)
